### PR TITLE
AuthorizedAlways replaces Authorized in latest iOS release.

### DIFF
--- a/LocationManager.swift
+++ b/LocationManager.swift
@@ -55,7 +55,7 @@ class LocationManager: NSObject,CLLocationManagerDelegate {
     private let verboseMessageDictionary = [CLAuthorizationStatus.NotDetermined:"You have not yet made a choice with regards to this application.",
         CLAuthorizationStatus.Restricted:"This application is not authorized to use location services. Due to active restrictions on location services, the user cannot change this status, and may not have personally denied authorization.",
         CLAuthorizationStatus.Denied:"You have explicitly denied authorization for this application, or location services are disabled in Settings.",
-        CLAuthorizationStatus.Authorized:"App is Authorized to use location services.",CLAuthorizationStatus.AuthorizedWhenInUse:"You have granted authorization to use your location only when the app is visible to you."]
+        CLAuthorizationStatus.AuthorizedAlways:"App is Authorized to always use location services.",CLAuthorizationStatus.AuthorizedWhenInUse:"You have granted authorization to use your location only when the app is visible to you."]
     
     
     var delegate:LocationManagerDelegate? = nil


### PR DESCRIPTION
I believe this is all that is required to support the latest iOS release. `Authorized` is no longer available on `CLAuthorizationStatus`, `AuthorizedAlways` appears to be favored.

I'm not positive the demo app is running as expected with this change, so it may not be merge worthy. Nonetheless, this is the only change I needed to make to get this working in my iOS project.