### PR TITLE
Remove sensor parameter

### DIFF
--- a/LocationManager.swift
+++ b/LocationManager.swift
@@ -372,7 +372,7 @@ class LocationManager: NSObject,CLLocationManagerDelegate {
   
   private func geoCodeUsignGoogleAddress(address:NSString){
     
-    var urlString = "http://maps.googleapis.com/maps/api/geocode/json?address=\(address)&sensor=true" as NSString
+    var urlString = "http://maps.googleapis.com/maps/api/geocode/json?address=\(address)" as NSString
     
     urlString = urlString.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding)!
     
@@ -393,7 +393,7 @@ class LocationManager: NSObject,CLLocationManagerDelegate {
   
   private func reverseGocodeUsingGoogle(#latitude:Double, longitude: Double){
     
-    var urlString = "http://maps.googleapis.com/maps/api/geocode/json?latlng=\(latitude),\(longitude)&sensor=true" as NSString
+    var urlString = "http://maps.googleapis.com/maps/api/geocode/json?latlng=\(latitude),\(longitude)" as NSString
     
     urlString = urlString.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding)!
     


### PR DESCRIPTION
The sensor parameter is no longer required according to [Google Documentation](https://developers.google.com/maps/articles/geolocation#SpecifyingSensor)