### PR TITLE
Prevent Transport Security error

### DIFF
--- a/LocationManager.swift
+++ b/LocationManager.swift
@@ -415,7 +415,7 @@ class LocationManager: NSObject,CLLocationManagerDelegate {
     
     private func geoCodeUsignGoogleAddress(address:NSString){
         
-        var urlString = "http://maps.googleapis.com/maps/api/geocode/json?address=\(address)&sensor=true" as NSString
+        var urlString = "https://maps.googleapis.com/maps/api/geocode/json?address=\(address)&sensor=true" as NSString
         
         urlString = urlString.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding)!
         
@@ -439,7 +439,7 @@ class LocationManager: NSObject,CLLocationManagerDelegate {
     
     private func reverseGocodeUsingGoogle(latitude latitude:Double, longitude: Double){
         
-        var urlString = "http://maps.googleapis.com/maps/api/geocode/json?latlng=\(latitude),\(longitude)&sensor=true" as NSString
+        var urlString = "https://maps.googleapis.com/maps/api/geocode/json?latlng=\(latitude),\(longitude)&sensor=true" as NSString
         
         urlString = urlString.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding)!
         


### PR DESCRIPTION
When trying to access a resource through http instead of https on iOS 9, Xcode will throw a `Transport security has blocked a cleartext HTTP` error. By using https by default, this is fixed.

More info in [this stackoverflow question](http://stackoverflow.com/questions/31254725/transport-security-has-blocked-a-cleartext-http)
